### PR TITLE
Bump untilBuild to 203 to make compatible with 2020.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'Git Scope'
-version '3.0.2'
+version '3.0.3'
 
 sourceCompatibility = 8
 
@@ -27,16 +27,16 @@ intellij {
 
 patchPluginXml {
     sinceBuild '193'
-    untilBuild '202'
+    untilBuild '203'
     changeNotes """
         <h2>Bugfixes</h2>
         <ul>
             <li>
-                Fix Bug where Diff-Window shows only the loader icon
+                Updated to be compatible with 2020.2
             </li>
         </ul>
     """
 }
 publishPlugin {
-    token intellijPublishToken
+    token findProperty('intellijPublishToken') ?: 'no_token_given'
 }


### PR DESCRIPTION
I couldn't upgrade to 2020.2, since GitScope wasn't compatible with it. I'm not sure if this is all that is necessary, but it appears to build.